### PR TITLE
Add: ヘッダーを追加

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,3 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+@import 'application';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,102 @@
+/*==========================================
+              カラーの変数定義 
+==========================================*/
+$background-color: #fffdf8;
+$navbar-color: #fff7e7;
+$dark-font-color: #4e3300;
+$light-font-color: #c2b9a8;
+$white-font-color: #fdfdfd;
 
-nav {
-  /*background-color: #888;*/
+
+/*------------------------------------------*/
+body {
+  background-color: $background-color;
+  color: $dark-font-color;
+  font-family: 'Zen Kaku Gothic New', sans-serif;
 }
 
+/*------------------------------------------*/
+
+/*==========================================
+                   header 
+==========================================*/
+
+.navbar {
+  background-color: $navbar-color;
+}
+
+.container-fluid {
+  height: 52px;
+}
+
+.navbar-brand {
+  font-family: 'Josefin Sans', sans-serif;
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: $dark-font-color;
+}
+
+/*リンクのクリック可能範囲を広げる*/
+nav.navbar .container-fluid ul.navbar-nav {
+  height: 100%;
+}
+nav.navbar .container-fluid ul.navbar-nav li {
+  height: 100%;
+}
+nav.navbar .container-fluid ul.navbar-nav li a {
+  height: 100%;
+  font-size: 1.0rem;
+  color: $dark-font-color;
+}
+
+nav button.btn.dropdown-toggle {
+  height: 100%;
+  font-size: 1.3rem;
+  color: $dark-font-color;
+}
+
+/*Infoリスト展開時の色*/
+nav.navbar .container-fluid ul.dropdown-menu {
+  background-color: $background-color;
+  border: 0.5px solid $light-font-color;
+}
+
+/*------------------------------------------*/
+
+/*#dropdown-toggle-without-arrowの枠を非表示にする*/
+#dropdown-toggle-without-arrow {
+  border: none;
+}
+
+/*#dropdown-toggle-without-arrowの矢印を非表示にする*/
+#dropdown-toggle-without-arrow::after {
+  display: none;
+}
+
+/*------------------------------------------*/
+
+/*nabvarのリンクがホバー・フォーカスなどの状態の時の色を変更*/
+.navbar a:hover,
+.navbar a:active,
+.navbar a:focus {
+  background-color: transparent;
+  color: $light-font-color;
+}
+
+/*新規登録・ログインのリンクがホバー・フォーカスなどの状態の時の色を変更*/
+nav.navbar .container-fluid ul.navbar-nav li a:hover,
+nav.navbar .container-fluid ul.navbar-nav li a:active,
+nav.navbar .container-fluid ul.navbar-nav li a:focus {
+  background-color: transparent;
+  color: $light-font-color;
+}
+
+/*Informationアイコンがホバー・フォーカスなどの状態の時の色を変更*/
+nav button.btn.dropdown-toggle:hover,
+nav button.btn.dropdown-toggle:active,
+nav button.btn.dropdown-toggle:focus {
+  background-color: transparent;
+  color: $light-font-color;
+}
+
+/*------------------------------------------*/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,5 @@
+
+nav {
+  /*background-color: #888;*/
+}
+

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,6 +9,9 @@ html
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
     script src="https://unpkg.com/@phosphor-icons/web"
+    link rel="preconnect" href="https://fonts.googleapis.com"
+    link rel="preconnect" href="https://fonts.gstatic.com" crossorigin=""
+    link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300&display=swap" rel="stylesheet"
   body
     = render 'layouts/header'
     = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,6 +12,9 @@ html
     link rel="preconnect" href="https://fonts.googleapis.com"
     link rel="preconnect" href="https://fonts.gstatic.com" crossorigin=""
     link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300&display=swap" rel="stylesheet"
+    link rel="preconnect" href="https://fonts.googleapis.com"
+    link rel="preconnect" href="https://fonts.gstatic.com" crossorigin=""
+    link href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@300;400;700&display=swap" rel="stylesheet"
   body
-    = render 'layouts/header'
+    = render 'shared/header'
     = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,5 +8,7 @@ html
     = csp_meta_tag
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
+    script src="https://unpkg.com/@phosphor-icons/web"
   body
+    = render 'layouts/header'
     = yield

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,0 +1,22 @@
+header
+  nav.navbar
+    .container-fluid
+      = link_to "pathfinder", root_path, class: "navbar-brand"
+
+      ul.navbar-nav.ms-auto.d-flex.flex-row.align-items-center
+        li.nav-item
+          = link_to "新規登録", "#", class: "nav-link d-flex align-items-center p-2 me-2"
+        li.nav-item
+          = link_to "ログイン", "#", class: "nav-link d-flex align-items-center p-2 me-1"
+      button.btn.dropdown-toggle.ps-2.pe-2.me-1#dropdown-toggle-without-arrow type="button" data-bs-toggle="dropdown" aria-expanded="false"
+        i.ph.ph-info
+
+      ul.dropdown-menu.dropdown-menu-end.me-2
+        li
+          = link_to "pathfinderについて", "#", class: "dropdown-item"
+        li
+          = link_to "利用規約", "#", class: "dropdown-item"
+        li
+          = link_to "プライバシーポリシー", "#", class: "dropdown-item"
+        li
+          = link_to "お問い合わせ", "#", class: "dropdown-item"


### PR DESCRIPTION
## 関連するIssue
close #22 

## 概要
ヘッダーとそれに必要なスタイルシートを作成

- [`e3c110d`](https://github.com/ju17nana/walk_on_alleyways/commit/e3c110d6378319b29400d2a5ac242e4c2f754bd1) でアプリのスタイルを記述するSCSSファイルを作成し、反映を確認
- [`0e7ea8e`](https://github.com/ju17nana/walk_on_alleyways/commit/0e7ea8ef95f55e3a891058ff04c5a47da234a13f) でPhosphor Iconsを導入
- [`b0308d2`](https://github.com/ju17nana/walk_on_alleyways/commit/b0308d272c68276bc0d7a4c8d888ae7f16d807a8) と [`552fe89`](https://github.com/ju17nana/walk_on_alleyways/commit/552fe89772b14d0b45b1e7e147cc946bae6c3c17) でGoogle Fontsからフォントを導入
- [`0828117`](https://github.com/ju17nana/walk_on_alleyways/commit/0828117928c297756e756bee990f0a5fc75d910f) でヘッダーの内容と必要なスタイルを記述


## 確認方法
- [x] ヘッダーのレイアウトが正しいこと
- [x] 画面の大きさを変更しても変わらないこと
- [x] リンク上をホバーするとフォントカラーが薄茶に変化すること

## 確認結果
ヘッダーのレイアウト
<img width="1100" alt="スクリーンショット 2024-01-18 17 05 22" src="https://github.com/ju17nana/walk_on_alleyways/assets/100750293/6caad5de-5490-48e2-aee9-6b07771c1b31">

スマホサイズでのレイアウト
<img width="1102" alt="スクリーンショット 2024-01-18 22 32 39" src="https://github.com/ju17nana/walk_on_alleyways/assets/100750293/e485337f-1949-4907-9631-a4c0dd257e4f">


リンク上をホバー
![画面収録-2024-01-18-17 11 46](https://github.com/ju17nana/walk_on_alleyways/assets/100750293/c2369946-3745-4018-b88f-02e32ea59ec6)

## コメント
以下の二点に関してはJSを必要とする改善点なので、別Issueで取り組む
- #70 
- #71 
