### PR TITLE
Fix: Fly.ioに再デプロイを実行

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,44 +1,27 @@
-# fly.toml app configuration file generated for path-finder on 2024-01-10T14:14:02+09:00
+# fly.toml app configuration file generated for back-pathfinder on 2024-02-07T23:57:19+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = "path-finder"
-primary_region = "nrt"
-console_command = "/rails/bin/rails console"
+app = 'back-pathfinder'
+primary_region = 'nrt'
+console_command = '/rails/bin/rails console'
 
 [build]
-
-[deploy]
-  release_command = "./bin/rails db:prepare"
 
 [http_service]
   internal_port = 3000
   force_https = true
   auto_stop_machines = false
   auto_start_machines = true
-  min_machines_running = 1
-  processes = ["app"]
-
-[checks]
-  [checks.status]
-    port = 3000
-    type = "http"
-    interval = "10s"
-    timeout = "2s"
-    grace_period = "5s"
-    method = "GET"
-    path = "/up"
-    protocol = "http"
-    tls_skip_verify = false
-    [checks.status.headers]
-      X-Forwarded-Proto = "https"
+  min_machines_running = 0
+  processes = ['app']
 
 [[vm]]
-  cpu_kind = "shared"
+  cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 256
 
 [[statics]]
-  guest_path = "/rails/public"
-  url_prefix = "/"
+  guest_path = '/rails/public'
+  url_prefix = '/'


### PR DESCRIPTION
## 関連するIssue
close #84 

## 概要
前回の設定がFly.ioの無料枠を出ていたので、無料枠に収まるよう設定し直し再デプロイを行った
- [`e87a8be`](https://github.com/ju17nana/walk_on_alleyways/commit/e87a8beb1f1995c8fcbb8a289f016a9566eff27c)でFly.ioの設定を修正

## 確認方法
- [x] [https://back-pathfinder.fly.dev/](https://back-pathfinder.fly.dev/) へアクセスし、エラーが発生しないことを確認する。
- [x] `localhost:3000`での表示と同じ表示がされていることを確認する。
- [x] [https://back-pathfinder.com](https://back-pathfinder.com)や[https://www.back-pathfinder.com](https://www.back-pathfinder.com)でもエラーが生じず、`localhost:3000`での表示と同じ表示がされていることを確認する。
- [x] fly.toml の vm の箇所が以下の設定になっていることを確認する
  ```bash
  memory_mb = 256
  ```

## 確認結果
`localhost:3000`での表示
<img width="826" alt="スクリーンショット 2024-02-08 20 29 32" src="https://github.com/ju17nana/walk_on_alleyways/assets/100750293/d59db0d0-6a77-40aa-84b3-8ac7786927f8">

[https://back-pathfinder.fly.dev/](https://back-pathfinder.fly.dev/) での表示
<img width="825" alt="スクリーンショット 2024-02-08 20 29 10" src="https://github.com/ju17nana/walk_on_alleyways/assets/100750293/9d0d664f-2562-4f3b-831c-2f4c150d37bf">

[https://back-pathfinder.com](https://back-pathfinder.com)での表示
<img width="827" alt="スクリーンショット 2024-02-08 20 28 13" src="https://github.com/ju17nana/walk_on_alleyways/assets/100750293/4d51dfe9-4215-4737-b88b-990500ab9d13">

[https://www.back-pathfinder.com](https://www.back-pathfinder.com)での表示
<img width="825" alt="スクリーンショット 2024-02-08 20 28 25" src="https://github.com/ju17nana/walk_on_alleyways/assets/100750293/87ac6e08-4936-4054-b84a-5253f999de94">

